### PR TITLE
fix: add ability to use dashes in path names

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ export function isArray(arr) {
 }
 
 export function splitPath(str) {
-  const regex = /(\w+)|\[([^\]]+)\]/g
+  const regex = /([\w-]+)|\[([^\]]+)\]/g
   const result = []
   let path
 

--- a/tests/unit/utils.spec.js
+++ b/tests/unit/utils.spec.js
@@ -128,6 +128,13 @@ describe('splitPath', () => {
     const res = splitPath(path)
     expect(res).toEqual(pathArr)
   })
+
+  it('returns the correct value when path has dashes in name', () => {
+    const path = 'foo-dash[0].baz-double-dash.qux[1]'
+    const pathArr = ['foo-dash', '0', 'baz-double-dash', 'qux', '1']
+    const res = splitPath(path)
+    expect(res).toEqual(pathArr)
+  })
 })
 
 describe('getByPath', () => {


### PR DESCRIPTION
Added ability to use dashes in path names.
like: `foo-dash[0].baz-double-dash.qux[1]`