### PR TITLE
fix: implement prototype pollution safeguards

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,32 @@ export function isArray(arr) {
   return Array.isArray(arr)
 }
 
+export const UNSAFE_KEYS = Object.freeze(
+  (() => {
+    const keys = Object.create(null)
+
+    ;['__proto__', 'constructor', 'prototype'].forEach((unsafeKey) => {
+      keys[unsafeKey] = true
+    })
+
+    return keys
+  })(),
+)
+
+export function isUnsafeKey(key) {
+  return Object.prototype.hasOwnProperty.call(UNSAFE_KEYS, String(key))
+}
+
+export function assertSafePath(path) {
+  const parts = isArray(path) ? path : splitPath(path)
+
+  if (parts.some(isUnsafeKey)) {
+    throw Error('Path contains unsafe keys.')
+  }
+
+  return parts
+}
+
 export function splitPath(str) {
   const regex = /([\w\s-]+)|\[([^\]]+)\]/g
   const result = []

--- a/src/vueSetPath.js
+++ b/src/vueSetPath.js
@@ -1,8 +1,8 @@
 import Vue from 'vue'
-import { getByPath, isArray, isNumeric, isObject, splitPath } from './utils.js'
+import { assertSafePath, getByPath, isArray, isNumeric, isObject } from './utils.js'
 
 export const setOne = (obj, pathStr, value) => {
-  const path = splitPath(pathStr)
+  const path = assertSafePath(pathStr)
   const length = path.length
   const lastIndex = length - 1
 
@@ -56,7 +56,7 @@ export const setMany = (obj, path, value) => {
 }
 
 export const deleteOne = (obj, pathStr) => {
-  const path = splitPath(pathStr)
+  const path = assertSafePath(pathStr)
   const prop = path.pop()
 
   Vue.delete(getByPath(obj, path), prop)

--- a/tests/unit/vueSetPath.spec.js
+++ b/tests/unit/vueSetPath.spec.js
@@ -123,6 +123,69 @@ describe('setMany', () => {
   })
 })
 
+describe('prototype pollution safeguards', () => {
+  let obj
+
+  beforeEach(() => {
+    obj = {}
+    delete Object.prototype.polluted
+    delete Object.prototype.isAdmin
+  })
+
+  afterEach(() => {
+    delete Object.prototype.polluted
+    delete Object.prototype.isAdmin
+  })
+
+  it('throws on unsafe key in setOne root segment', () => {
+    const fn = () => {
+      setOne(obj, '__proto__.polluted', 'yes')
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.polluted).toBeUndefined()
+  })
+
+  it('throws on unsafe key in setOne nested segment', () => {
+    const fn = () => {
+      setOne(obj, 'a.__proto__.isAdmin', true)
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.isAdmin).toBeUndefined()
+  })
+
+  it('throws on constructor.prototype chain in setOne', () => {
+    const fn = () => {
+      setOne(obj, 'constructor.prototype.polluted', 'yes')
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.polluted).toBeUndefined()
+  })
+
+  it('throws on unsafe key in setMany string input', () => {
+    const fn = () => {
+      setMany(obj, '__proto__.polluted', 'yes')
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.polluted).toBeUndefined()
+  })
+
+  it('throws on unsafe key in setMany object input', () => {
+    const fn = () => {
+      setMany(obj, {
+        'safe.path': 'ok',
+        'a.__proto__.polluted': 'yes',
+      })
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.polluted).toBeUndefined()
+  })
+})
+
 describe('deleteOne', () => {
   let obj
 
@@ -148,6 +211,12 @@ describe('deleteOne', () => {
         },
       ],
     }
+
+    delete Object.prototype.polluted
+  })
+
+  afterEach(() => {
+    delete Object.prototype.polluted
   })
 
   it('deletes an object property', () => {
@@ -173,6 +242,15 @@ describe('deleteOne', () => {
     deleteOne(obj, 'arr[1].age')
     expect(obj.arr.length).toBe(3)
     expect(obj.arr[1]).toEqual({ name: 'George' })
+  })
+
+  it('throws on unsafe key path', () => {
+    const fn = () => {
+      deleteOne(obj, '__proto__.polluted')
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.polluted).toBeUndefined()
   })
 })
 
@@ -206,6 +284,12 @@ describe('deleteMany', () => {
         },
       ],
     }
+
+    delete Object.prototype.polluted
+  })
+
+  afterEach(() => {
+    delete Object.prototype.polluted
   })
 
   it('deletes both object properties and array items', () => {
@@ -228,5 +312,23 @@ describe('deleteMany', () => {
     }
 
     expect(test).toThrow('Arguments must be either string or array.')
+  })
+
+  it('throws on unsafe key path when input is string', () => {
+    const fn = () => {
+      deleteMany(obj, '__proto__.polluted')
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.polluted).toBeUndefined()
+  })
+
+  it('throws on unsafe key path when input is array', () => {
+    const fn = () => {
+      deleteMany(obj, ['foo.bar.baz', 'a.__proto__.polluted'])
+    }
+
+    expect(fn).toThrow('Path contains unsafe keys.')
+    expect({}.polluted).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
This PR fixes a prototype pollution vulnerability in path-based mutation methods by blocking unsafe path segments before traversal. Fixes https://github.com/kouts/vue-set-path/issues/11

## Changes
- Added path safety validation to reject unsafe keys:
  - `__proto__`
  - `constructor`
  - `prototype`
- Applied validation to:
  - `setOne`
  - `setMany` (via `setOne`)
  - `deleteOne`
  - `deleteMany` (via `deleteOne`)
- Added regression tests for:
  - unsafe root and nested segments
  - `setOne` / `setMany` malicious paths
  - `deleteOne` / `deleteMany` malicious paths
  - verification that `Object.prototype` is not modified
- Replaced `Set`-based unsafe key storage with an IE11-safe object map.
- Addressed linting compatibility (`no-proto`) in unsafe key map initialization.

## Security Impact
Prevents prototype chain mutation through crafted paths such as:
- `__proto__.polluted`
- `a.__proto__.isAdmin`
- `constructor.prototype.polluted`

Unsafe paths now throw:
`Path contains unsafe keys.`

## Compatibility
- Keeps behavior unchanged for valid/safe paths.
- Maintains IE11 compatibility (no reliance on `Set` for unsafe-key lookup).

## Validation
- `npm run lint-fix -- src/utils.js src/vueSetPath.js tests/unit/vueSetPath.spec.js`
- `pnpm test:unit` (all tests passing)